### PR TITLE
fix: add User type alias for OrganizationUser model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -606,3 +606,11 @@ class SystemLog(BaseModel, table=True):
     entity_type: str | None = Field(default=None, max_length=50)
     entity_id: UUID | None = Field(default=None)
     details: dict | None = Field(default=None, sa_column=Column(JSONB))
+
+
+# =============================================================================
+# TYPE ALIASES FOR BACKWARD COMPATIBILITY
+# =============================================================================
+
+# Alias for OrganizationUser to maintain compatibility with existing code
+User = OrganizationUser


### PR DESCRIPTION
- Added type alias User = OrganizationUser in models.py
- Resolves ImportError when deps.py tries to import User
- Maintains backward compatibility with existing code that references User
- Fixes uvicorn startup failure caused by missing User model