### PR TITLE
Candidate recruiter integration iteration I

### DIFF
--- a/Frontend/candidate-portal/src/components/CandidateLoginPage.tsx
+++ b/Frontend/candidate-portal/src/components/CandidateLoginPage.tsx
@@ -9,9 +9,10 @@ import { api } from '../services/api';
 interface CandidateLoginPageProps {
   onBack: () => void;
   onSignIn: () => void;
+  groupId?: string;
 }
 
-export function CandidateLoginPage({ onBack, onSignIn }: CandidateLoginPageProps) {
+export function CandidateLoginPage({ onBack, onSignIn, groupId }: CandidateLoginPageProps) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -23,7 +24,7 @@ export function CandidateLoginPage({ onBack, onSignIn }: CandidateLoginPageProps
     setError('');
 
     try {
-      await api.auth.login(email, password);
+      await api.auth.login(email, password, groupId);
       onSignIn();
     } catch (err) {
       setError('Invalid email or password');

--- a/Frontend/candidate-portal/src/components/LiveInterviewFlow.tsx
+++ b/Frontend/candidate-portal/src/components/LiveInterviewFlow.tsx
@@ -46,16 +46,40 @@ export function LiveInterviewFlow({ onSignOut, onExit, onCompletion }: LiveInter
   const [uploadProgress, setUploadProgress] = useState(0);
   const [conversationTurns, setConversationTurns] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [questions, setQuestions] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchQuestions = async () => {
       try {
         setIsLoading(true);
-        const data = await api.recruiter.getLiveInterviewQuestions('demo-interview-id') as any[];
-        setQuestions(data.map((q: any) => q.question));
+        // Get actual interview config for this candidate/group
+        const configData = await api.candidate.getInterviewConfig() as any;
+        
+        if (configData && configData.config_id) {
+          // If questions are present in config, use them
+          if (configData.questions && Array.isArray(configData.questions.items)) {
+            setQuestions(configData.questions.items.map((q: any) => q.text || q.question));
+          } else {
+            // Default questions if none in config
+            setQuestions([
+              "Describe your most challenging project and how you overcame the obstacles you faced.",
+              "Tell us about a time when you had to work with a difficult team member. How did you handle the situation?",
+              "What motivates you in your professional career, and how do you stay productive during challenging times?",
+              "Describe a situation where you had to learn a new technology or skill quickly. How did you approach it?",
+              "Where do you see yourself in 5 years, and how does this position align with your career goals?"
+            ]);
+          }
+
+          // Start the interview session in backend
+          const sessionData = await api.candidate.startInterview({ config_id: configData.config_id });
+          if (sessionData && sessionData.session_id) {
+            setSessionId(sessionData.session_id);
+            console.log('Started interview session:', sessionData.session_id);
+          }
+        }
       } catch (error) {
-        console.error('Failed to fetch live interview questions:', error);
+        console.error('Failed to fetch live interview configuration:', error);
         // Fallback to default questions if API fails
         setQuestions([
           "Describe your most challenging project and how you overcame the obstacles you faced.",
@@ -108,6 +132,13 @@ export function LiveInterviewFlow({ onSignOut, onExit, onCompletion }: LiveInter
           if (conversationTurns >= maxTurns - 1) {
             setShowUploadProgress(true);
             setUploadProgress(0);
+
+            // Sync with backend that interview is complete
+            if (sessionId) {
+              api.candidate.completeInterview({ session_id: sessionId })
+                .then(() => console.log('Interview completion synced with backend'))
+                .catch(err => console.error('Failed to sync interview completion:', err));
+            }
 
             const uploadInterval = setInterval(() => {
               setUploadProgress(prev => {
@@ -359,6 +390,13 @@ export function LiveInterviewFlow({ onSignOut, onExit, onCompletion }: LiveInter
       // Interview complete - show upload progress
       setShowUploadProgress(true);
       setUploadProgress(0);
+
+      // Sync completion with backend (if sessionId present)
+      if (sessionId) {
+        api.candidate.completeInterview({ session_id: sessionId })
+          .then(() => console.log('Interview completion synced with backend'))
+          .catch(err => console.error('Failed to sync interview completion:', err));
+      }
 
       const uploadInterval = setInterval(() => {
         setUploadProgress(prev => {

--- a/Frontend/candidate-portal/src/router.tsx
+++ b/Frontend/candidate-portal/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate, useNavigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate, useNavigate, useParams } from 'react-router-dom';
 import { CandidateLoginPage } from './components/CandidateLoginPage';
 import { CandidateHomePage } from './components/CandidateHomePage';
 import { CandidateDashboard } from './components/CandidateDashboard';
@@ -21,10 +21,13 @@ const ErrorPage = () => (
 // Wrapper Components for Navigation
 const CandidateLoginWrapper = () => {
     const navigate = useNavigate();
+    const { groupId } = useParams();
+    
     return (
         <CandidateLoginPage
             onBack={() => window.location.href = 'http://localhost:5173'}
             onSignIn={() => navigate('/home')}
+            groupId={groupId}
         />
     );
 };
@@ -93,7 +96,7 @@ export const router = createBrowserRouter([
         errorElement: <ErrorPage />,
     },
     {
-        path: "/login",
+        path: "/login/:groupId?",
         element: <CandidateLoginWrapper />,
         errorElement: <ErrorPage />,
     },

--- a/Frontend/candidate-portal/src/services/auth.service.ts
+++ b/Frontend/candidate-portal/src/services/auth.service.ts
@@ -1,11 +1,16 @@
 import { API_URL } from './client';
 
 export const authService = {
-    login: async (email: string, pass: string) => {
+    login: async (email: string, pass: string, groupId?: string) => {
+        const payload: any = { email, password: pass };
+        if (groupId) {
+            payload.group_id = groupId;
+        }
+
         const res = await fetch(`${API_URL}/candidate/login`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ email, password: pass })
+            body: JSON.stringify(payload)
         });
         if (!res.ok) throw new Error('Invalid credentials');
         const data = await res.json();
@@ -14,12 +19,16 @@ export const authService = {
         if (data.refresh_token) {
             localStorage.setItem('refresh_token', data.refresh_token);
         }
+        if (groupId) {
+            localStorage.setItem('current_group_id', groupId);
+        }
         return data;
     },
     getToken: () => localStorage.getItem('access_token'),
     logout: () => {
         localStorage.removeItem('access_token');
         localStorage.removeItem('refresh_token');
+        localStorage.removeItem('current_group_id');
     },
     isAuthenticated: () => !!localStorage.getItem('access_token'),
 };

--- a/Frontend/recruiter-portal/src/components/recruiter/assessments/CreateAdvancedAssessment.tsx
+++ b/Frontend/recruiter-portal/src/components/recruiter/assessments/CreateAdvancedAssessment.tsx
@@ -23,6 +23,7 @@ interface Section {
   variants: QuestionVariant[];
   points: number;
   selectionStrategy?: 'random' | 'sequential';
+  variantsToSelect?: number;
 }
 
 interface QuestionVariant {
@@ -101,7 +102,8 @@ export function CreateAdvancedAssessment({ onBack, onSave, initialData }: Create
       type: 'mcq',
       variants: [],
       points: 10,
-      selectionStrategy: 'random'
+      selectionStrategy: 'random',
+      variantsToSelect: 1
     };
     setSections([...sections, newSection]);
     setCurrentSectionIndex(sections.length);
@@ -321,7 +323,7 @@ export function CreateAdvancedAssessment({ onBack, onSave, initialData }: Create
                                   </span>
                                 </div>
                                 <div className="font-['Arimo',sans-serif] text-[12px] text-[#6b7280]">
-                                  {section.variants.length} {section.variants.length === 1 ? 'variant' : 'variants'} • {section.points} points
+                                  {section.variants.length} {section.variants.length === 1 ? 'variant' : 'variants'} • {section.variantsToSelect || 1} per candidate • {section.points} points
                                 </div>
                               </div>
                             </div>

--- a/Frontend/recruiter-portal/src/components/recruiter/groups/EnhancedGroupOverviewV2.tsx
+++ b/Frontend/recruiter-portal/src/components/recruiter/groups/EnhancedGroupOverviewV2.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ChevronLeft, Play, Edit, Download, Users, TrendingUp, Sparkles, Calendar, Send, CheckCircle, XCircle, AlertCircle, Clock, Eye, Trash2, UserPlus, UserMinus, Activity, MoreVertical, Flag, Filter, X, ChevronDown, Plus, UserCog, Shield, Lock, MessageSquare, FileText, CheckSquare, Ban, Archive, AlertTriangle, BarChart3, Target, Video, Loader2 } from 'lucide-react';
+import { ChevronLeft, Play, Edit, Download, Users, TrendingUp, Sparkles, Calendar, Send, CheckCircle, XCircle, AlertCircle, Clock, Eye, Trash2, UserPlus, UserMinus, MoreVertical, Flag, Filter, X, ChevronDown, Plus, UserCog, Shield, Lock, MessageSquare, FileText, CheckSquare, Ban, Archive, AlertTriangle, BarChart3, Target, Video, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { SuspectReviewPage } from '../candidates/SuspectReviewPage';
 import { CreateAdvancedAssessment } from '../assessments/CreateAdvancedAssessment';
@@ -232,7 +232,13 @@ export function EnhancedGroupOverviewV2({
   const [activeFlow, setActiveFlow] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [positionId, setPositionId] = useState<string>('');
-  const [interviewConfigId, setInterviewConfigId] = useState<string | null>(null);
+
+  // Reset any editing interview payload when switching flows or stages
+  // This prevents stale `editingInterviewData` causing "Edit" UI to appear
+  // when the user expects to create a new configuration for a different stage.
+  useEffect(() => {
+    setEditingInterviewData(null);
+  }, [activeFlow, currentStage]);
 
   // Fetch data on mount
   useEffect(() => {
@@ -243,10 +249,6 @@ export function EnhancedGroupOverviewV2({
         if (data.position_id) {
           setPositionId(data.position_id);
         }
-        if (data.interview_config_id) {
-          setInterviewConfigId(data.interview_config_id);
-        }
-
         let activeFlowRaw = filtrationFlow; // Default to prop
         if (data.group && data.group.filtration_flow) {
           // Parse backend response which might be object array or strings
@@ -407,7 +409,7 @@ export function EnhancedGroupOverviewV2({
       await api.recruiter.updateGroup(groupId, {
         filtration_flow: flowConfig,
         github_questions_count: configuredGithubQuestionsCount,
-      });
+      } as any);
       setGithubQuestionsCount(configuredGithubQuestionsCount);
       setShowFlowConfigModal(false);
       setRefreshKey(prev => prev + 1); // Trigger refresh
@@ -1413,9 +1415,13 @@ export function EnhancedGroupOverviewV2({
                           showToast('Cannot modify configuration - stage is active');
                           return;
                         }
+                        if (groupAssessments.length > 0) {
+                          showToast('Only one assessment can be created for this group');
+                          return;
+                        }
                         setShowAssessmentCreation(true);
                       }}
-                      disabled={stageConfigLocked}
+                      disabled={stageConfigLocked || groupAssessments.length > 0}
                       className="flex-1 flex items-center justify-center gap-2 h-[40px] px-[16px] rounded-[8px] bg-gradient-to-r from-[#10b981] to-[#059669] hover:from-[#059669] hover:to-[#047857] text-white transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <Plus size={16} />
@@ -1424,29 +1430,37 @@ export function EnhancedGroupOverviewV2({
                       </span>
                     </button>
                   )}
-                  {(activeFlow.includes('ai-interview') || activeFlow.includes('live-interview')) && (
-                    <button
-                      onClick={() => {
-                        if (stageConfigLocked) {
-                          showToast('Cannot modify configuration - stage is active');
-                          return;
-                        }
-                        const hasLive = activeFlow.includes('live-interview') || activeFlow.includes('live_interview');
-                        const hasRecorded = activeFlow.includes('ai-interview') || activeFlow.includes('ai_interview');
-                        if (hasRecorded || hasLive) {
+                  {(activeFlow.includes('ai-interview') || activeFlow.includes('live-interview')) && (() => {
+                    const hasRecordedReq = activeFlow.includes('ai-interview') || activeFlow.includes('ai_interview');
+                    const hasLiveReq = activeFlow.includes('live-interview') || activeFlow.includes('live_interview');
+                    const hasRecordedCfg = groupInterviews.some(i => i.interview_type === 'recorded');
+                    const hasLiveCfg = groupInterviews.some(i => i.interview_type === 'live' || i.interview_type === 'live_ai');
+                    const isFullyConfigured = (!hasRecordedReq || hasRecordedCfg) && (!hasLiveReq || hasLiveCfg);
+                    
+                    return (
+                      <button
+                        onClick={() => {
+                          if (stageConfigLocked) {
+                            showToast('Cannot modify configuration - stage is active');
+                            return;
+                          }
+                          if (isFullyConfigured) {
+                            showToast('Only one interview can be created for each stage');
+                            return;
+                          }
+                          setEditingInterviewData(null);
                           setShowUnifiedAIInterviewSetup(true);
-                        }
-                      }}
-                      disabled={stageConfigLocked}
-                      className="flex-1 flex items-center justify-center gap-2 h-[40px] px-[16px] rounded-[8px] bg-gradient-to-r from-[#10b981] to-[#059669] hover:from-[#059669] hover:to-[#047857] text-white transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      <Activity size={16} />
-                      <span className="font-['Arimo',sans-serif] text-[14px]">
-                        {interviewConfigId ? 'Edit AI Interview Settings' : 'AI Interview Settings'}
-                      </span>
-                      {interviewConfigId && <CheckCircle size={16} className="text-white ml-1" />}
-                    </button>
-                  )}
+                        }}
+                        disabled={stageConfigLocked || isFullyConfigured}
+                        className="flex-1 flex items-center justify-center gap-2 h-[40px] px-[16px] rounded-[8px] bg-gradient-to-r from-[#10b981] to-[#059669] hover:from-[#059669] hover:to-[#047857] text-white transition-colors shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <Plus size={16} />
+                        <span className="font-['Arimo',sans-serif] text-[14px]">
+                          Add AI Interview Settings
+                        </span>
+                      </button>
+                    );
+                  })()}
                 </div>
 
               </div>

--- a/Frontend/recruiter-portal/src/components/recruiter/interviews/SectionEditor.tsx
+++ b/Frontend/recruiter-portal/src/components/recruiter/interviews/SectionEditor.tsx
@@ -14,6 +14,7 @@ interface Section {
   type: 'mcq' | 'essay' | 'code';
   variants: QuestionVariant[];
   points: number;
+  variantsToSelect: number;
   selectionStrategy?: 'random' | 'sequential';
 }
 
@@ -65,9 +66,13 @@ type CreationMethod = null | 'manual' | 'ai' | 'bank';
 type EditingVariant = { index: number; variant: QuestionVariant } | null;
 
 export function SectionEditor({ section, onSave, onCancel }: SectionEditorProps) {
-  // Ensure selectionStrategy has a default value if missing
-  const initialSection = { ...section, selectionStrategy: section.selectionStrategy || 'random' };
-  const [currentSection, setCurrentSection] = useState<Section>(initialSection as Section);
+  // Ensure defaults exist when editing older section payloads.
+  const initialSection: Section = {
+    ...section,
+    selectionStrategy: section.selectionStrategy || 'random',
+    variantsToSelect: section.variantsToSelect || 1,
+  };
+  const [currentSection, setCurrentSection] = useState<Section>(initialSection);
   const [creationMethod, setCreationMethod] = useState<CreationMethod>(null);
   const [showQuestionBank, setShowQuestionBank] = useState(false);
   const [showAIGenerator, setShowAIGenerator] = useState(false);

--- a/Frontend/recruiter-portal/src/components/recruiter/interviews/SectionEditor.tsx
+++ b/Frontend/recruiter-portal/src/components/recruiter/interviews/SectionEditor.tsx
@@ -310,7 +310,7 @@ export function SectionEditor({ section, onSave, onCancel }: SectionEditorProps)
           </div>
 
           {/* Points & Strategy */}
-          <div className="grid grid-cols-2 gap-6 mb-6">
+          <div className="grid grid-cols-3 gap-6 mb-6">
             <div>
               <label className="block font-['Arimo',sans-serif] text-[14px] text-[#374151] mb-2">
                 Points for this Section
@@ -321,6 +321,23 @@ export function SectionEditor({ section, onSave, onCancel }: SectionEditorProps)
                 onChange={(e) => setCurrentSection({ ...currentSection, points: parseInt(e.target.value) || 0 })}
                 min="1"
                 max="100"
+                className="w-full h-[44px] px-4 rounded-[8px] border border-[#e5e7eb] font-['Arimo',sans-serif] text-[14px] focus:outline-none focus:ring-2 focus:ring-[#6366f1] focus:border-transparent"
+              />
+            </div>
+
+            <div>
+              <label className="block font-['Arimo',sans-serif] text-[14px] text-[#374151] mb-2">
+                Questions per candidate
+              </label>
+              <input
+                type="number"
+                value={currentSection.variantsToSelect || 1}
+                onChange={(e) => {
+                  let val = parseInt(e.target.value) || 1;
+                  if (val < 1) val = 1;
+                  setCurrentSection({ ...currentSection, variantsToSelect: val });
+                }}
+                min="1"
                 className="w-full h-[44px] px-4 rounded-[8px] border border-[#e5e7eb] font-['Arimo',sans-serif] text-[14px] focus:outline-none focus:ring-2 focus:ring-[#6366f1] focus:border-transparent"
               />
             </div>

--- a/Frontend/recruiter-portal/src/services/recruiter.service.ts
+++ b/Frontend/recruiter-portal/src/services/recruiter.service.ts
@@ -310,7 +310,7 @@ export const recruiterService = {
         });
     },
 
-    updateGroup: async (groupId: string, data: { name?: string; status?: string; filtration_flow?: string[] }) => {
+    updateGroup: async (groupId: string, data: { name?: string; status?: string; filtration_flow?: string[]; github_questions_count?: number }) => {
         return fetchAPI<any>(`/recruiter/groups/${groupId}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },

--- a/backend/app/api/v1/candidate_interview.py
+++ b/backend/app/api/v1/candidate_interview.py
@@ -11,8 +11,8 @@ import json
 from uuid import UUID
 from fastapi import APIRouter, HTTPException, BackgroundTasks, UploadFile, File, Form
 from pydantic import BaseModel
-from sqlalchemy import text, bindparam
-from sqlalchemy.dialects.postgresql import UUID as pgUUID
+from sqlalchemy import text, bindparam, String
+from sqlalchemy.dialects.postgresql import UUID as pgUUID, JSONB
 
 from app.api.deps import CurrentCandidate, DbSession
 
@@ -148,23 +148,18 @@ async def get_interview_config(candidate: CurrentCandidate, session: DbSession):
     
     Returns questions, time limits, and instructions.
     """
-    # Get the candidate's ai_interview stage config
-    result = await session.execute(
+    # Resolve the active stage first so live interviews can use their AI mirror config.
+    stage_result = await session.execute(
         text("""
             SELECT 
-                aic.config_id,
-                aic.title,
-                aic.instructions,
-                aic.questions,
-                COALESCE(aic.think_time_seconds, 30) as think_time,
-                COALESCE(aic.answer_time_seconds, 120) as answer_time,
-                COALESCE(aic.max_retakes, 1) as max_retakes
+                gps.stage_type,
+                gps.config_id,
+                gps.acceptance_criteria
             FROM candidate_applications ca
-            JOIN group_pipeline_stages gps ON ca.group_id = gps.group_id AND gps.stage_type = 'ai_interview'
+            JOIN group_pipeline_stages gps ON ca.group_id = gps.group_id AND gps.stage_type IN ('ai_interview', 'live_interview')
             JOIN candidate_pipeline_progress cpp
                 ON cpp.application_id = ca.application_id
                 AND cpp.stage_id = gps.stage_id
-            JOIN ai_interview_configs aic ON gps.config_id = aic.config_id
             WHERE ca.candidate_id = :cid
               AND gps.state = 'active'
               AND cpp.status IN ('unlocked', 'in_progress')
@@ -175,13 +170,107 @@ async def get_interview_config(candidate: CurrentCandidate, session: DbSession):
         ),
         {"cid": candidate.candidate_id}
     )
-    row = result.fetchone()
+    stage_row = stage_result.mappings().first()
     
+    if not stage_row:
+        raise HTTPException(status_code=404, detail="No AI interview configured for this candidate")
+
+    if stage_row["stage_type"] == "live_interview":
+        criteria = stage_row["acceptance_criteria"] or {}
+        mirror_id = None
+        if isinstance(criteria, dict):
+            mirror_id = criteria.get("candidate_interview_config_id") or criteria.get("interview_config_id")
+
+        if mirror_id:
+            result = await session.execute(
+                text("""
+                    SELECT 
+                        aic.config_id,
+                        aic.title,
+                        aic.instructions,
+                        aic.questions,
+                        COALESCE(aic.think_time_seconds, 30) as think_time,
+                        COALESCE(aic.answer_time_seconds, 120) as answer_time,
+                        COALESCE(aic.max_retakes, 1) as max_retakes
+                    FROM ai_interview_configs aic
+                    WHERE aic.config_id = :cid
+                      AND aic.is_deleted = false
+                    LIMIT 1
+                """).bindparams(
+                    bindparam("cid", type_=pgUUID(as_uuid=True)),
+                ),
+                {"cid": UUID(str(mirror_id))}
+            )
+            row = result.fetchone()
+            if row:
+                normalized_questions = _normalize_questions(row[3] or {})
+                return InterviewConfigResponse(
+                    config_id=str(row[0]),
+                    title=row[1],
+                    instructions=row[2],
+                    questions=normalized_questions,
+                    think_time_seconds=row[4],
+                    answer_time_seconds=row[5],
+                    max_retakes=row[6],
+                )
+
+        live_result = await session.execute(
+            text("""
+                SELECT 
+                    lic.config_id,
+                    lic.title,
+                    lic.instructions,
+                    lic.suggested_questions,
+                    COALESCE(lic.duration_minutes, 60) as duration_minutes
+                FROM live_interview_configs lic
+                WHERE lic.config_id = :cid
+                  AND lic.is_deleted = false
+                LIMIT 1
+            """).bindparams(
+                bindparam("cid", type_=pgUUID(as_uuid=True)),
+            ),
+            {"cid": UUID(str(stage_row["config_id"]))}
+        )
+        row = live_result.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="No live interview configured for this candidate")
+
+        normalized_questions = _normalize_questions(row[3] or {})
+        return InterviewConfigResponse(
+            config_id=str(row[0]),
+            title=row[1],
+            instructions=row[2],
+            questions=normalized_questions,
+            think_time_seconds=30,
+            answer_time_seconds=120,
+            max_retakes=1,
+        )
+
+    result = await session.execute(
+        text("""
+            SELECT 
+                aic.config_id,
+                aic.title,
+                aic.instructions,
+                aic.questions,
+                COALESCE(aic.think_time_seconds, 30) as think_time,
+                COALESCE(aic.answer_time_seconds, 120) as answer_time,
+                COALESCE(aic.max_retakes, 1) as max_retakes
+            FROM ai_interview_configs aic
+            WHERE aic.config_id = :cid
+              AND aic.is_deleted = false
+            LIMIT 1
+        """).bindparams(
+            bindparam("cid", type_=pgUUID(as_uuid=True)),
+        ),
+        {"cid": UUID(str(stage_row["config_id"]))}
+    )
+    row = result.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="No AI interview configured for this candidate")
-    
+
     normalized_questions = _normalize_questions(row[3] or {})
-    
+
     return InterviewConfigResponse(
         config_id=str(row[0]),
         title=row[1],
@@ -213,52 +302,121 @@ async def start_interview_session(
         text("""
             SELECT 
                 ca.application_id,
-                aic.organization_id,
-                aic.interview_type,
+                gps.stage_type,
+                gps.config_id,
+                gps.acceptance_criteria,
                 cpp.progress_id,
                 cpp.status
             FROM candidate_applications ca
             JOIN group_pipeline_stages gps ON ca.group_id = gps.group_id 
-                AND gps.stage_type = 'ai_interview'
+                AND gps.stage_type IN ('ai_interview', 'live_interview')
             JOIN candidate_pipeline_progress cpp
                 ON cpp.application_id = ca.application_id
                 AND cpp.stage_id = gps.stage_id
-            JOIN ai_interview_configs aic ON gps.config_id = aic.config_id
             WHERE ca.candidate_id = :cid 
-                AND aic.config_id = :config_id
                 AND gps.state = 'active'
                 AND cpp.status IN ('unlocked', 'in_progress')
                 AND (ca.is_deleted = false OR ca.is_deleted IS NULL)
             LIMIT 1
         """).bindparams(
             bindparam("cid", type_=pgUUID(as_uuid=True)),
-            bindparam("config_id", type_=pgUUID(as_uuid=True)),
         ),
-        {"cid": candidate.candidate_id, "config_id": UUID(request.config_id)}
+        {"cid": candidate.candidate_id}
     )
-    row = result.fetchone()
+    row = result.mappings().first()
     
     if not row:
         raise HTTPException(status_code=404, detail="No matching interview configuration found")
     
-    application_id = str(row[0])
-    organization_id = str(row[1])
-    interview_type = row[2] or "recorded"
-    progress_id = row[3]
+    application_id = str(row["application_id"])
+    stage_type = row["stage_type"]
+    stage_config_id = row["config_id"]
+    criteria = row["acceptance_criteria"] or {}
+    progress_id = row["progress_id"]
+    interview_type = "recorded"
+
+    # Resolve the actual AI interview config used for the ongoing session.
+    resolved_config_id = None
+    if stage_type == "live_interview" and isinstance(criteria, dict):
+        resolved_config_id = criteria.get("candidate_interview_config_id") or criteria.get("interview_config_id")
+    else:
+        resolved_config_id = stage_config_id
+
+    if not resolved_config_id:
+        raise HTTPException(status_code=404, detail="No interview configuration found for this stage")
+
+    config_lookup = await session.execute(
+        text("""
+            SELECT config_id, organization_id, interview_type
+            FROM ai_interview_configs
+            WHERE config_id = :config_id
+              AND is_deleted = false
+            LIMIT 1
+        """).bindparams(
+            bindparam("config_id", type_=pgUUID(as_uuid=True)),
+        ),
+        {"config_id": UUID(str(resolved_config_id))}
+    )
+    config_row = config_lookup.mappings().first()
+    if config_row:
+        organization_id = str(config_row["organization_id"])
+        interview_type = config_row["interview_type"] or ("live_ai" if stage_type == "live_interview" else "recorded")
+    elif stage_type == "live_interview":
+        # Fallback: if the AI mirror is missing, create a minimal one from the live config.
+        from app.models import AIInterviewConfig, LiveInterviewConfig
+
+        live_lookup = await session.execute(
+            text("""
+                SELECT config_id, organization_id, position_id, title, instructions, suggested_questions, duration_minutes
+                FROM live_interview_configs
+                WHERE config_id = :config_id
+                  AND is_deleted = false
+                LIMIT 1
+            """).bindparams(
+                bindparam("config_id", type_=pgUUID(as_uuid=True)),
+            ),
+            {"config_id": UUID(str(stage_config_id))}
+        )
+        live_row = live_lookup.mappings().first()
+        if not live_row:
+            raise HTTPException(status_code=404, detail="No matching interview configuration found")
+
+        mirror_cfg = AIInterviewConfig(
+            organization_id=UUID(str(live_row["organization_id"])),
+            position_id=live_row["position_id"],
+            title=live_row["title"] or "Live Interview",
+            interview_type="live_ai",
+            instructions=live_row["instructions"],
+            max_retakes=1,
+            questions=live_row["suggested_questions"] or {"items": []},
+            total_duration_minutes=live_row["duration_minutes"] or 60,
+            show_ai_feedback=True,
+            recording_required=True,
+        )
+        session.add(mirror_cfg)
+        await session.flush()
+        resolved_config_id = mirror_cfg.config_id
+        organization_id = str(mirror_cfg.organization_id)
+        interview_type = mirror_cfg.interview_type
+    else:
+        raise HTTPException(status_code=404, detail="No matching interview configuration found")
+    
+    # Map interview_type to stage_type
+    current_stage_type = 'ai_interview' if interview_type == 'recorded' else 'live_interview'
 
     existing_result = await session.execute(
         text("""
             SELECT session_id
             FROM ongoing_interviews
             WHERE application_id = :app_id
-              AND config_id = :config_id
+                AND config_id = :config_id
               AND status IN ('in_progress', 'not_started')
             LIMIT 1
         """).bindparams(
             bindparam("app_id", type_=pgUUID(as_uuid=True)),
             bindparam("config_id", type_=pgUUID(as_uuid=True)),
         ),
-        {"app_id": UUID(application_id), "config_id": UUID(request.config_id)}
+        {"app_id": UUID(application_id), "config_id": UUID(str(resolved_config_id))}
     )
     existing_session = existing_result.fetchone()
     if existing_session:
@@ -278,14 +436,15 @@ async def start_interview_session(
                 UPDATE candidate_pipeline_progress
                 SET status = 'in_progress',
                     session_id = :sid,
-                    session_type = 'ai_interview',
+                    session_type = :stype,
                     started_at = COALESCE(started_at, NOW())
                 WHERE progress_id = :progress_id
             """).bindparams(
                 bindparam("sid", type_=pgUUID(as_uuid=True)),
                 bindparam("progress_id", type_=pgUUID(as_uuid=True)),
+                bindparam("stype", type_=String),
             ),
-            {"sid": existing_session[0], "progress_id": progress_id}
+            {"sid": existing_session[0], "progress_id": progress_id, "stype": current_stage_type}
         )
         await session.commit()
         return StartSessionResponse(
@@ -307,14 +466,15 @@ async def start_interview_session(
             bindparam("sid", type_=pgUUID(as_uuid=True)),
             bindparam("config_id", type_=pgUUID(as_uuid=True)),
             bindparam("app_id", type_=pgUUID(as_uuid=True)),
-            bindparam("org_id", type_=pgUUID(as_uuid=True)),
+                bindparam("org_id", type_=pgUUID(as_uuid=True)),
+                bindparam("itype", type_=String),
         ),
         {
             "sid": UUID(session_id),
-            "config_id": UUID(request.config_id),
             "app_id": UUID(application_id),
             "org_id": UUID(organization_id),
-            "itype": interview_type,
+                "config_id": UUID(str(resolved_config_id)),
+                "itype": interview_type,
         }
     )
 
@@ -588,7 +748,7 @@ async def complete_interview_session(
     # Verify the session belongs to this candidate
     result = await session.execute(
         text("""
-            SELECT oi.session_id, ca.application_id, ca.group_id
+            SELECT oi.session_id, ca.application_id, ca.group_id, oi.interview_type
             FROM ongoing_interviews oi
             JOIN candidate_applications ca ON oi.application_id = ca.application_id
             WHERE oi.session_id = :sid AND ca.candidate_id = :cid
@@ -605,6 +765,7 @@ async def complete_interview_session(
     
     application_id = row["application_id"]
     group_id = row["group_id"]
+    interview_type = row["interview_type"]
     
     # Update session status
     await session.execute(
@@ -618,25 +779,38 @@ async def complete_interview_session(
         {"sid": UUID(request.session_id)}
     )
     
+    # Map backend interview types to pipeline stage types
+    stage_type = 'ai_interview' if interview_type == 'recorded' else 'live_interview'
+    
     # Update candidate pipeline progress for this stage
     await session.execute(
         text("""
-            UPDATE candidate_pipeline_progress cpp
+            UPDATE candidate_pipeline_progress
             SET status = 'completed',
                 completed_at = NOW(),
                 session_id = :sid,
-                session_type = 'ai_interview'
-            FROM ongoing_interviews oi
-            JOIN candidate_applications ca ON oi.application_id = ca.application_id
-            JOIN group_pipeline_stages gps ON ca.group_id = gps.group_id 
-                AND gps.stage_type = 'ai_interview'
-            WHERE oi.session_id = :sid
-              AND cpp.application_id = ca.application_id
-              AND cpp.stage_id = gps.stage_id
+                session_type = :session_type
+            WHERE application_id = :application_id
+              AND stage_id IN (
+                  SELECT gps.stage_id 
+                  FROM group_pipeline_stages gps
+                  WHERE gps.group_id = :group_id
+                    AND gps.stage_type = :stage_type
+              )
         """).bindparams(
             bindparam("sid", type_=pgUUID(as_uuid=True)),
+            bindparam("application_id", type_=pgUUID(as_uuid=True)),
+            bindparam("group_id", type_=pgUUID(as_uuid=True)),
+            bindparam("session_type", type_=String),
+            bindparam("stage_type", type_=String),
         ),
-        {"sid": UUID(request.session_id)}
+        {
+            "sid": UUID(request.session_id),
+            "application_id": application_id,
+            "group_id": group_id,
+            "session_type": stage_type,
+            "stage_type": stage_type
+        }
     )
     
     # --- Trigger Recruiter Notification ---
@@ -670,12 +844,18 @@ async def complete_interview_session(
                     gen_random_uuid(), :org_id, :uid,
                     'stage_completed', :title, :msg, :data, false, NOW()
                 )
-            """),
+            """).bindparams(
+                bindparam("org_id", type_=pgUUID(as_uuid=True)),
+                bindparam("uid", type_=pgUUID(as_uuid=True)),
+                bindparam("title", type_=String),
+                bindparam("msg", type_=String),
+                bindparam("data", type_=JSONB),
+            ),
             {
-                "org_id": str(recruiter_row[1]),
-                "uid": str(recruiter_row[0]),
-                "title": "AI Interview Completed",
-                "msg": f"Candidate {recruiter_row[2]} has completed their AI interview for group {recruiter_row[3]}.",
+                "org_id": UUID(str(recruiter_row[1])),
+                "uid": UUID(str(recruiter_row[0])),
+                "title": f"{'Live' if interview_type != 'recorded' else 'AI'} Interview Completed",
+                "msg": f"Candidate {recruiter_row[2]} has completed their {'live' if interview_type != 'recorded' else 'AI'} interview for group {recruiter_row[3]}.",
                 "data": {"session_id": str(request.session_id), "application_id": str(recruiter_row[4])}
             }
         )

--- a/backend/app/api/v1/candidate_portal.py
+++ b/backend/app/api/v1/candidate_portal.py
@@ -30,7 +30,7 @@ async def candidate_login(data: CandidateLoginRequest, session: DbSession):
     Returns access and refresh tokens.
     """
     service = CandidateAuthService(session)
-    return await service.login(data.email, data.password)
+    return await service.login(data.email, data.password, data.group_id)
 
 
 @router.post("/refresh", response_model=TokenResponse)

--- a/backend/app/schemas/assessments.py
+++ b/backend/app/schemas/assessments.py
@@ -56,6 +56,7 @@ class SectionCreate(BaseModel):
     type: str = Field(description="mcq, essay, or coding")
     points: int
     selectionStrategy: str = Field(default="random")
+    variantsToSelect: Optional[int] = Field(default=1)
     variants: List[QuestionCreate]
 
 # =============================================================================

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -78,6 +78,7 @@ class CandidateLoginRequest(BaseModel):
     """Candidate login request body."""
     email: EmailStr
     password: str
+    group_id: UUID | None = None  # Optional group ID from frontend login URL
 
 
 class CandidateAuthResponse(BaseModel):

--- a/backend/app/schemas/group.py
+++ b/backend/app/schemas/group.py
@@ -280,6 +280,8 @@ class AssignInterviewRequest(BaseModel):
     interview_config_id: UUID | None = None
     create_new: bool = False
     interview_config: dict | None = None
+    config: dict | None = None
+    interviewConfig: dict | None = None
 
 
 class AssignInterviewResponse(BaseModel):

--- a/backend/app/services/assessments.py
+++ b/backend/app/services/assessments.py
@@ -18,6 +18,15 @@ class AssessmentService:
 
     async def create_assessment(self, request_data: AssessmentCreateRequest, user_id: UUID, organization_id: UUID) -> Assessment:
         try:
+            existing_assessment_q = select(Assessment.id).where(
+                Assessment.group_id == request_data.group_id,
+                Assessment.organization_id == organization_id,
+                Assessment.is_deleted == False,
+            )
+            existing_assessment_res = await self.session.execute(existing_assessment_q)
+            if existing_assessment_res.scalars().first():
+                raise HTTPException(status_code=400, detail="Only one assessment can be created for this group")
+
             # 1. Create Assessment Record
             # Combine basic settings with specific fields from the request
             assessment = Assessment(
@@ -52,7 +61,7 @@ class AssessmentService:
                     section_order=section_data.order,
                     section_title=f"Section {section_data.order}", # Using a default title as none was provided by the frontend payload mapping
                     question_type=db_section_type,
-                    variants_to_select=len(section_data.variants), # By default, selecting all created variants
+                    variants_to_select=section_data.variantsToSelect or 1,
                     points_per_question=section_data.points,
                     selection_strategy=section_data.selectionStrategy
                 )
@@ -257,7 +266,8 @@ class AssessmentService:
                 "type": sec_frontend_type,
                 "variants": variants,
                 "points": sec.points_per_question,
-                "selectionStrategy": sec.selection_strategy
+                "selectionStrategy": sec.selection_strategy,
+                "variantsToSelect": sec.variants_to_select
             })
 
         return {
@@ -323,7 +333,7 @@ class AssessmentService:
                     section_order=section_data.order,
                     section_title=f"Section {section_data.order}",
                     question_type=db_section_type,
-                    variants_to_select=len(section_data.variants),
+                    variants_to_select=section_data.variantsToSelect or 1,
                     points_per_question=section_data.points,
                     selection_strategy=section_data.selectionStrategy
                 )

--- a/backend/app/services/candidates/auth.py
+++ b/backend/app/services/candidates/auth.py
@@ -18,14 +18,14 @@ class CandidateAuthService:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def login(self, email: str, password: str) -> TokenResponse:
+    async def login(self, email: str, password: str, group_id: UUID | None = None) -> TokenResponse:
         """
         authenticate and return the jwt
         """
         import traceback
         try:
-            print(f"[DEBUG] Attempting login for email: {email}")
-            candidate = await self._get_candidate_by_email(email)
+            print(f"[DEBUG] Attempting login for email: {email}, group_id: {group_id}")
+            candidate = await self._get_candidate_by_email(email, group_id)
             print(f"[DEBUG] Candidate lookup result: {candidate}")
             
             if not candidate:
@@ -101,14 +101,26 @@ class CandidateAuthService:
         
         return candidate
 
-    async def _get_candidate_by_email(self, email: str) -> CandidateProfile | None:
-        """Get candidate by email."""
+    async def _get_candidate_by_email(self, email: str, group_id: UUID | None = None) -> CandidateProfile | None:
+        """Get candidate by email, filtering by group_id if provided to ensure correct user context."""
+        from app.models import CandidateApplication
+
         statement = select(CandidateProfile).where(
             CandidateProfile.email == email,
             CandidateProfile.is_deleted == False
         )
+        
+        if group_id:
+            statement = statement.join(
+                CandidateApplication,
+                CandidateProfile.id == CandidateApplication.candidate_id
+            ).where(
+                CandidateApplication.group_id == group_id,
+                CandidateApplication.is_deleted == False
+            )
+            
         result = await self.session.execute(statement)
-        return result.scalar_one_or_none()
+        return result.scalars().first()
 
     async def _get_candidate_by_id(self, candidate_id: UUID) -> CandidateProfile | None:
         """Get candidate by ID."""

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -31,6 +31,11 @@ class EmailService:
         """Core function to send an email."""
         if not settings.SMTP_USER or not settings.SMTP_PASSWORD:
             logger.warning(f"SMTP not fully configured. Simulating email to {email_to} with subject '{subject}'")
+            logger.info("\n" + "="*50)
+            logger.info(f"EMAIL SENT TO: {email_to}")
+            logger.info(f"SUBJECT: {subject}")
+            logger.info(f"BODY:\n{html_content}")
+            logger.info("="*50 + "\n")
             return
             
         message = MessageSchema(
@@ -83,15 +88,17 @@ class EmailService:
         await EmailService.send_email_async(subject, email, html)
 
     @staticmethod
-    async def send_stage_invitation_email(email: str, name: str, stage_title: str):
+    async def send_stage_invitation_email(email: str, name: str, stage_title: str, group_id: str):
         """Sent when a recruiter starts a stage for a candidate."""
+        login_url = f"https://eramatch.com/login/{group_id}"
         subject = f"Action Required: EraMatch {stage_title} Invitation"
         html = f"""
         <html>
             <body>
                 <h2>Hello {name},</h2>
                 <p>You have been invited to complete the <strong>{stage_title}</strong> stage for your application.</p>
-                <p>Please log in to your Candidate Portal to begin this stage.</p>
+                <p>Please use the link below to log in and begin this stage:</p>
+                <p><a href="{login_url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: #fff; text-decoration: none; border-radius: 6px;">Log In & Start {stage_title}</a></p>
                 <p>We wish you the best of luck!</p>
                 <br>
                 <p>Best regards,<br>The EraMatch Recruiting Team</p>
@@ -129,6 +136,40 @@ class EmailService:
                 <p>We are thrilled to extend you an offer for the position of <strong>{position_title}</strong>.</p>
                 <p>Please log in to your Candidate Portal to review the details of your offer and provide your decision.</p>
                 <p>We look forward to welcoming you to the team!</p>
+                <br>
+                <p>Best regards,<br>The EraMatch Recruiting Team</p>
+            </body>
+        </html>
+        """
+        await EmailService.send_email_async(subject, email, html)
+
+    @staticmethod
+    async def send_group_credentials_email(
+        email: str, name: str, group_name: str,
+        temp_password: str, group_id: str
+    ):
+        """Sent when a candidate is added to a new group with fresh credentials."""
+        login_url = f"https://eramatch.com/login/{group_id}"
+        subject = f"EraMatch - Your New Group Credentials"
+        html = f"""
+        <html>
+            <body>
+                <h2>Hello {name},</h2>
+                <p>You have been added to a new candidate group: <strong>{group_name}</strong>.</p>
+                <p>Your login credentials for this group are:</p>
+                <table style="border-collapse: collapse; margin: 16px 0;">
+                    <tr>
+                        <td style="padding: 8px 16px; border: 1px solid #ddd; font-weight: bold;">Email</td>
+                        <td style="padding: 8px 16px; border: 1px solid #ddd;"><code>{email}</code></td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 8px 16px; border: 1px solid #ddd; font-weight: bold;">Password</td>
+                        <td style="padding: 8px 16px; border: 1px solid #ddd;"><code>{temp_password}</code></td>
+                    </tr>
+                </table>
+                <p>Use the following link to log in:</p>
+                <p><a href="{login_url}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: #fff; text-decoration: none; border-radius: 6px;">Log In to Your Portal</a></p>
+                <p>Please keep these credentials safe. For security, we recommend changing your password upon first login.</p>
                 <br>
                 <p>Best regards,<br>The EraMatch Recruiting Team</p>
             </body>

--- a/backend/app/services/group.py
+++ b/backend/app/services/group.py
@@ -1726,7 +1726,7 @@ class GroupService:
             )
             cfg = res.scalars().first()
             if cfg:
-                self.session.delete(cfg)
+                await self.session.delete(cfg)
 
             if sc.acceptance_criteria and isinstance(sc.acceptance_criteria, dict):
                 candidate_ai_id = sc.acceptance_criteria.get("candidate_interview_config_id")

--- a/backend/app/services/group.py
+++ b/backend/app/services/group.py
@@ -63,6 +63,7 @@ from app.schemas.group import (
     CandidateProgressResponse,
     CandidateScores,
     CandidateStageStatus,
+    GroupCreateRequest,
     FiltrationFlowStage,
     GroupAssessmentItem,
     GroupInterviewItem,
@@ -74,6 +75,7 @@ from app.schemas.group import (
     MonitoringFlag,
     StageStatsResponse,
     ScheduleInterviewRequest,
+    GroupUpdateRequest,
     GroupDeleteRequest,
 )
 
@@ -215,7 +217,6 @@ class GroupService:
     async def _get_candidates_progress_data(
         self, group_id: UUID, filter_str: str | None = None, sort_str: str | None = None, stage_type_filter: str | None = None
     ) -> list[CandidateProgressItem]:
-        # Acceptance criteria for meets_criteria calculation
         sc_res = await self.session.execute(
             select(GroupStageConfig)
             .where(
@@ -225,20 +226,20 @@ class GroupService:
             .order_by(GroupStageConfig.stage_order.asc())
         )
         stage_configs = sc_res.scalars().all()
+
         ordered_flow_types: list[str] = []
         for sc in stage_configs:
             if sc.stage_type not in ordered_flow_types:
                 ordered_flow_types.append(sc.stage_type)
+
         min_score = 70.0
         allowed_risk = "Low"
         for sc in stage_configs:
             if sc.acceptance_criteria and isinstance(sc.acceptance_criteria, dict):
                 min_score = sc.acceptance_criteria.get("min_technical_score", min_score)
-                min_score = sc.acceptance_criteria.get("min_technical_score", min_score)
-                allowed_integrity_risk = sc.acceptance_criteria.get("allowed_integrity_risk", allowed_risk)
+                allowed_risk = sc.acceptance_criteria.get("allowed_integrity_risk", allowed_risk)
 
-        # Fetch applications + candidate profiles
-        q = (
+        app_res = await self.session.execute(
             select(CandidateApplication, CandidateProfile)
             .join(CandidateProfile, CandidateApplication.candidate_id == CandidateProfile.id)
             .where(
@@ -246,15 +247,12 @@ class GroupService:
                 CandidateApplication.is_deleted == False,
             )
         )
-        res = await self.session.execute(q)
-        rows = res.all()
-
+        rows = app_res.all()
         if not rows:
             return []
 
         app_ids = [app.id for app, _ in rows]
 
-        # Fetch stage progress for all apps in one query
         prog_res = await self.session.execute(
             select(CandidateStageProgress, GroupStageConfig.stage_type)
             .join(GroupStageConfig, CandidateStageProgress.stage_id == GroupStageConfig.stage_id)
@@ -263,33 +261,24 @@ class GroupService:
                 GroupStageConfig.group_id == group_id,
             )
         )
-        all_progress = prog_res.all()
-        # Index by (application_id, stage_type)
         prog_map: dict[tuple[UUID, str], CandidateStageProgress] = {}
-        for p, s_type in all_progress:
-            prog_map[(p.application_id, s_type)] = p
+        for prog, stage_type in prog_res.all():
+            prog_map[(prog.application_id, stage_type)] = prog
 
-        # Fetch live interview sessions
         live_res = await self.session.execute(
             select(LiveInterviewSession).where(LiveInterviewSession.application_id.in_(app_ids))
         )
-        all_live_sessions = live_res.scalars().all()
-        live_map = {ls.application_id: ls for ls in all_live_sessions}
+        live_map = {ls.application_id: ls for ls in live_res.scalars().all()}
 
-        # Fetch flags
         flag_res = await self.session.execute(
             select(ProctoringFlag).where(ProctoringFlag.application_id.in_(app_ids))
         )
-        all_flags = flag_res.scalars().all()
         flag_map: dict[UUID, list[ProctoringFlag]] = {}
-        for f in all_flags:
-            flag_map.setdefault(f.application_id, []).append(f)
+        for flag in flag_res.scalars().all():
+            flag_map.setdefault(flag.application_id, []).append(flag)
 
-        # Fetch notes existence
         notes_res = await self.session.execute(
-            select(RecruiterNote.application_id).where(
-                RecruiterNote.application_id.in_(app_ids)
-            )
+            select(RecruiterNote.application_id).where(RecruiterNote.application_id.in_(app_ids))
         )
         apps_with_notes = set(notes_res.scalars().all())
 
@@ -298,23 +287,20 @@ class GroupService:
 
         items: list[CandidateProgressItem] = []
         for app, cand in rows:
-            # Build dynamic stage statuses and scores for ALL stages in the flow
             stage_statuses: dict[str, str] = {}
             stage_scores: dict[str, float | None] = {}
             stage_passed: dict[str, bool | None] = {}
-            
+
             for st_type in ordered_flow_types:
                 prog = prog_map.get((app.id, st_type))
                 stage_statuses[st_type] = prog.status if prog else "locked"
-                stage_scores[st_type] = float(prog.score) if (prog and prog.score is not None) else None
+                stage_scores[st_type] = float(prog.score) if prog and prog.score is not None else None
                 stage_passed[st_type] = prog.passed if prog else None
 
-            # Hard gate downstream stages by previous-stage completion to prevent
-            # stale progress rows from exposing candidates in later-stage views.
-            for idx, stage_type in enumerate(ordered_flow_types):
-                if idx == 0:
+            for index, stage_type in enumerate(ordered_flow_types):
+                if index == 0:
                     continue
-                prev_stage_type = ordered_flow_types[idx - 1]
+                prev_stage_type = ordered_flow_types[index - 1]
                 if stage_statuses.get(prev_stage_type) != "completed":
                     stage_statuses[stage_type] = "locked"
                     stage_scores[stage_type] = None
@@ -336,69 +322,57 @@ class GroupService:
 
             app_flags = flag_map.get(app.id, [])
             integrity_flags = [
-                IntegrityFlag(
-                    severity=f.severity,
-                    stage=f.session_type,
-                    description=f.event_type,
-                )
+                IntegrityFlag(severity=f.severity, stage=f.session_type, description=f.event_type)
                 for f in app_flags
             ]
 
-            # Determine meets_criteria
-            max_flag_sev = max(
-                (risk_levels.get(f.severity.lower(), 0) for f in app_flags), default=0
-            )
+            max_flag_sev = max((risk_levels.get(f.severity.lower(), 0) for f in app_flags), default=0)
             score_ok = (assess_score is not None and assess_score >= min_score) if assess_score is not None else True
             risk_ok = max_flag_sev <= allowed_level
             meets = score_ok and risk_ok
 
-            # Verdict
-            # Respect explicit passed/failed status from bulk_progress if set
             if assess_status == "failed" or ai_status == "failed":
                 verdict = "fail"
             elif assess_status == "completed" and ai_status == "completed":
-                # Check for explicit 'passed' boolean if available, otherwise use meets_criteria
-                # Note: In this context, we are looking at the status strings.
                 verdict = "pass" if meets else "fail"
             elif assess_status == "completed" or ai_status == "completed":
                 verdict = "conditional"
             else:
                 verdict = "pending"
 
-            # Construct dynamic stages dict
-            dynamic_stages = {}
+            stages: dict[str, CandidateStageStatus] = {}
             for st_type in ordered_flow_types:
-                s_at = scheduled_at if st_type == "live_interview" else None
-                m_l = meeting_link if st_type == "live_interview" else None
-                dynamic_stages[st_type] = CandidateStageStatus(
+                stages[st_type] = CandidateStageStatus(
                     score=stage_scores.get(st_type),
                     status=stage_statuses.get(st_type, "locked"),
                     passed=stage_passed.get(st_type),
-                    scheduled_at=s_at,
-                    meeting_link=m_l
+                    scheduled_at=scheduled_at if st_type == "live_interview" else None,
+                    meeting_link=meeting_link if st_type == "live_interview" else None,
                 )
 
-            items.append(CandidateProgressItem(
-                application_id=app.id,
-                candidate_id=cand.id,
-                name=cand.full_name,
-                email=cand.email,
-                assessment=CandidateStageStatus(score=assess_score, status=assess_status, passed=assess_passed),
-                ai_interview=CandidateStageStatus(score=ai_score, status=ai_status, passed=ai_passed),
-                live_interview=CandidateStageStatus(
-                    score=live_score,
-                    status=live_status,
-                    passed=live_passed,
-                    scheduled_at=scheduled_at,
-                    meeting_link=meeting_link
-                ),
-                stages=dynamic_stages,
-                meets_criteria=meets,
-                verdict=verdict,
-                flags=integrity_flags,
-                status=app.status if app.status else "active",
-                has_notes=app.id in apps_with_notes,
-            ))
+            items.append(
+                CandidateProgressItem(
+                    application_id=app.id,
+                    candidate_id=cand.id,
+                    name=cand.full_name,
+                    email=cand.email,
+                    assessment=CandidateStageStatus(score=assess_score, status=assess_status, passed=assess_passed),
+                    ai_interview=CandidateStageStatus(score=ai_score, status=ai_status, passed=ai_passed),
+                    live_interview=CandidateStageStatus(
+                        score=live_score,
+                        status=live_status,
+                        passed=live_passed,
+                        scheduled_at=scheduled_at,
+                        meeting_link=meeting_link,
+                    ),
+                    stages=stages,
+                    meets_criteria=meets,
+                    verdict=verdict,
+                    flags=integrity_flags,
+                    status=app.status if app.status else "active",
+                    has_notes=app.id in apps_with_notes,
+                )
+            )
 
         # Filter by stage_type_filter if provided
         if stage_type_filter:
@@ -472,10 +446,8 @@ class GroupService:
         for sc in stage_configs:
             if sc.stage_type == "assessment" and sc.acceptance_criteria:
                 assessment_config_id = sc.acceptance_criteria.get("assessment_id") if isinstance(sc.acceptance_criteria, dict) else None
-            if sc.stage_type in ["ai_interview", "live_interview"] and sc.acceptance_criteria:
-                found_id = sc.acceptance_criteria.get("interview_config_id") if isinstance(sc.acceptance_criteria, dict) else None
-                if found_id:
-                    interview_config_id = found_id
+            if sc.stage_type in ["ai_interview", "live_interview"] and sc.config_id:
+                interview_config_id = sc.config_id
 
         # Acceptance criteria — merge from all stage configs
         criteria = AcceptanceCriteriaResponse()
@@ -576,38 +548,89 @@ class GroupService:
                     )
                 )
 
-        interviews_res = await self.session.execute(
-            select(AIInterviewConfig).where(
-                AIInterviewConfig.position_id == group.position_id,
-                AIInterviewConfig.is_deleted == False
-            ).order_by(AIInterviewConfig.created_at.desc())
+        ai_interviews_res = await self.session.execute(
+            select(AIInterviewConfig, GroupStageConfig.stage_type)
+            .join(GroupStageConfig, GroupStageConfig.config_id == AIInterviewConfig.config_id)
+            .where(
+                GroupStageConfig.group_id == group.id,
+                GroupStageConfig.stage_type == "ai_interview",
+                AIInterviewConfig.organization_id == self.org_id,
+                AIInterviewConfig.is_deleted == False,
+            )
+            .order_by(GroupStageConfig.stage_order.asc(), AIInterviewConfig.updated_at.desc(), AIInterviewConfig.created_at.desc())
         )
-        interviews_db = interviews_res.scalars().all()
+        live_interviews_res = await self.session.execute(
+            select(LiveInterviewConfig, GroupStageConfig.stage_type)
+            .join(GroupStageConfig, GroupStageConfig.config_id == LiveInterviewConfig.id)
+            .where(
+                GroupStageConfig.group_id == group.id,
+                GroupStageConfig.stage_type == "live_interview",
+                LiveInterviewConfig.organization_id == self.org_id,
+            )
+            .order_by(GroupStageConfig.stage_order.asc(), LiveInterviewConfig.created_at.desc())
+        )
 
         interviews_data = []
-        if interviews_db:
-            if not interview_config_id:
-                interview_config_id = interviews_db[0].config_id
+        ai_interviews_db = ai_interviews_res.all()
+        live_interviews_db = live_interviews_res.all()
 
-            for ic_db in interviews_db:
-                q_count = len(ic_db.questions.get("items", [])) if isinstance(ic_db.questions, dict) else 0
+        combined_interviews = [
+            (cfg, stage_type, "ai") for cfg, stage_type in ai_interviews_db
+        ] + [
+            (cfg, stage_type, "live") for cfg, stage_type in live_interviews_db
+        ]
+        combined_interviews.sort(
+            key=lambda item: (
+                next((sc.stage_order for sc in stage_configs if sc.stage_type == item[1] and sc.config_id == (item[0].config_id if item[2] == "ai" else item[0].id)), 0),
+                item[0].updated_at if item[2] == "ai" and hasattr(item[0], "updated_at") else item[0].created_at,
+            )
+        )
+
+        if combined_interviews and not interview_config_id:
+            first_cfg = combined_interviews[0][0]
+            interview_config_id = first_cfg.config_id if hasattr(first_cfg, "config_id") else first_cfg.id
+
+        for cfg, stage_type, cfg_kind in combined_interviews:
+            if cfg_kind == "ai":
+                q_count = len(cfg.questions.get("items", [])) if isinstance(cfg.questions, dict) else 0
                 interviews_data.append(
                     GroupInterviewItem(
-                        id=ic_db.config_id,
-                        title=ic_db.title,
-                        interview_type=ic_db.interview_type,
-                        max_retakes=ic_db.max_retakes,
+                        id=cfg.config_id,
+                        title=cfg.title,
+                        interview_type=cfg.interview_type,
+                        max_retakes=cfg.max_retakes,
                         questions_count=q_count,
-                        instructions=ic_db.instructions,
-                        questions=ic_db.questions,
-                        think_time_seconds=ic_db.think_time_seconds,
-                        answer_time_seconds=ic_db.answer_time_seconds,
-                        live_interview_context=ic_db.live_interview_context,
-                        difficulty=ic_db.difficulty,
-                        show_ai_feedback=ic_db.show_ai_feedback,
-                        recording_required=ic_db.recording_required,
-                        total_duration_minutes=ic_db.total_duration_minutes,
-                        live_flow_config=ic_db.live_flow_config
+                        instructions=cfg.instructions,
+                        questions=cfg.questions,
+                        think_time_seconds=cfg.think_time_seconds,
+                        answer_time_seconds=cfg.answer_time_seconds,
+                        live_interview_context=cfg.live_interview_context,
+                        difficulty=cfg.difficulty,
+                        show_ai_feedback=cfg.show_ai_feedback,
+                        recording_required=cfg.recording_required,
+                        total_duration_minutes=cfg.total_duration_minutes,
+                        live_flow_config=cfg.live_flow_config,
+                    )
+                )
+            else:
+                q_count = len(cfg.suggested_questions.get("items", [])) if isinstance(cfg.suggested_questions, dict) else 0
+                interviews_data.append(
+                    GroupInterviewItem(
+                        id=cfg.id,
+                        title=cfg.title,
+                        interview_type="live_ai",
+                        max_retakes=1,
+                        questions_count=q_count,
+                        instructions=cfg.instructions,
+                        questions=cfg.suggested_questions or {},
+                        think_time_seconds=None,
+                        answer_time_seconds=None,
+                        live_interview_context=None,
+                        difficulty="Mid Level",
+                        show_ai_feedback=True,
+                        recording_required=True,
+                        total_duration_minutes=cfg.duration_minutes,
+                        live_flow_config=cfg.scoring_rubric,
                     )
                 )
         return GroupDetailResponse(
@@ -933,7 +956,8 @@ class GroupService:
                         await EmailService.send_stage_invitation_email(
                             email=profile.email,
                             name=profile.full_name,
-                            stage_title=stage_name_title
+                            stage_title=stage_name_title,
+                            group_id=str(group_id)
                         )
                     except Exception as e:
                         print(f"Failed to send real stage invitation email to {profile.email}: {e}")
@@ -1243,11 +1267,27 @@ class GroupService:
             )
         elif request.action == "transfer" and request.transfer_group_id:
             # Move to another group
+            # First, collect candidate_ids before the bulk update
+            transfer_res = await self.session.execute(
+                select(CandidateApplication.candidate_id, CandidateApplication.position_id)
+                .where(CandidateApplication.group_id == group_id)
+            )
+            transfer_rows = transfer_res.all()
+            transferred_candidate_ids = [row.candidate_id for row in transfer_rows]
+            transfer_position_id = transfer_rows[0].position_id if transfer_rows else None
+
             await self.session.execute(
                 update(CandidateApplication)
                 .where(CandidateApplication.group_id == group_id)
                 .values(group_id=request.transfer_group_id)
             )
+
+            # Generate new credentials for the transferred candidates in their new group
+            if transferred_candidate_ids and transfer_position_id:
+                target_group = await self._get_group(request.transfer_group_id)
+                await self._generate_and_send_group_credentials(
+                    transferred_candidate_ids, transfer_position_id, target_group
+                )
         else: # "release" or default
             # Just unassign
             await self.session.execute(
@@ -1406,79 +1446,246 @@ class GroupService:
         self, group_id: UUID, data: AssignInterviewRequest
     ) -> AssignInterviewResponse:
         group = await self._get_group(group_id)
+        interview_cfg = data.interview_config or data.config or data.interviewConfig
+        should_create_new = bool(data.create_new or (interview_cfg and not data.interview_config_id))
 
         config_id: UUID | None = None
+        stage_type_to_update: str | None = None
 
-        if data.interview_config_id:
-            # Validate existence
-            res = await self.session.execute(
-                select(AIInterviewConfig).where(
-                    AIInterviewConfig.config_id == data.interview_config_id,
-                    AIInterviewConfig.organization_id == self.org_id,
-                )
-            )
-            cfg = res.scalars().first()
-            if not cfg:
-                return AssignInterviewResponse(status=-1, message="Interview configuration not found")
-            
-            # If config data is provided, update existing
-            if data.interview_config:
-                ic = data.interview_config
-                cfg.title = ic.get("title", cfg.title)
-                cfg.instructions = ic.get("instructions", cfg.instructions)
-                cfg.max_retakes = ic.get("max_retakes", cfg.max_retakes)
-                cfg.questions = ic.get("questions", cfg.questions)
-                cfg.live_interview_context = ic.get("live_interview_context", cfg.live_interview_context)
-                cfg.difficulty = ic.get("difficulty", cfg.difficulty)
-                cfg.total_duration_minutes = ic.get("duration", cfg.total_duration_minutes)
-                cfg.show_ai_feedback = ic.get("showAIFeedback", cfg.show_ai_feedback)
-                cfg.recording_required = ic.get("recordingRequired", cfg.recording_required)
-                cfg.live_flow_config = ic.get("live_flow_config", cfg.live_flow_config)
-                cfg.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
-                self.session.add(cfg)
-            
-            config_id = cfg.config_id
-            ic_type = cfg.interview_type
-
-        elif data.create_new and data.interview_config:
-            # Create new AI interview config
-            ic = data.interview_config
-            ic_type = ic.get("interview_type", "recorded")
-            new_cfg = AIInterviewConfig(
-                organization_id=self.org_id,
-                position_id=group.position_id,
-                title=ic.get("title", "Untitled Interview"),
-                interview_type=ic_type,
-                instructions=ic.get("instructions"),
-                max_retakes=ic.get("max_retakes", 1),
-                questions=ic.get("questions", []),
-                live_interview_context=ic.get("live_interview_context"),
-                difficulty=ic.get("difficulty", "Mid Level"),
-                total_duration_minutes=ic.get("duration", 30),
-                show_ai_feedback=ic.get("showAIFeedback", True),
-                recording_required=ic.get("recordingRequired", True),
-                live_flow_config=ic.get("live_flow_config"),
-                created_by_user_id=self.user.id,
-            )
-            self.session.add(new_cfg)
-            await self.session.flush()
-            config_id = new_cfg.config_id
-        else:
-            return AssignInterviewResponse(status=-1, message="Provide interview_config_id or create_new with config")
-
-        stage_type_to_update = "live_interview" if ic_type == "live" else "ai_interview"
-
-        # Update the group's AI interview stage config
         sc_res = await self.session.execute(
             select(GroupStageConfig).where(
                 GroupStageConfig.group_id == group_id,
-                GroupStageConfig.stage_type == stage_type_to_update,
+                GroupStageConfig.stage_type.in_(["ai_interview", "live_interview"]),
             )
         )
-        sc = sc_res.scalars().first()
+        stage_configs = sc_res.scalars().all()
+
+        if should_create_new and interview_cfg:
+            # Create new AI interview config
+            ic = interview_cfg
+            ic_type = ic.get("interview_type", "recorded")
+            stage_type_to_update = "live_interview" if ic_type == "live_ai" else "ai_interview"
+            existing_stage_config = next((sc for sc in stage_configs if sc.stage_type == stage_type_to_update), None)
+            if existing_stage_config and existing_stage_config.config_id:
+                if stage_type_to_update == "live_interview":
+                    current_cfg_res = await self.session.execute(
+                        select(LiveInterviewConfig).where(
+                            LiveInterviewConfig.id == existing_stage_config.config_id,
+                            LiveInterviewConfig.organization_id == self.org_id,
+                        )
+                    )
+                    current_cfg = current_cfg_res.scalars().first()
+                    if current_cfg:
+                        raise BadRequestException("Only one interview configuration can be created for this stage")
+                    existing_stage_config.config_id = None
+                    if existing_stage_config.acceptance_criteria and isinstance(existing_stage_config.acceptance_criteria, dict):
+                        criteria = existing_stage_config.acceptance_criteria.copy()
+                        criteria.pop("interview_config_id", None)
+                        criteria.pop("candidate_interview_config_id", None)
+                        existing_stage_config.acceptance_criteria = criteria
+                    self.session.add(existing_stage_config)
+                else:
+                    current_cfg_res = await self.session.execute(
+                        select(AIInterviewConfig).where(
+                            AIInterviewConfig.config_id == existing_stage_config.config_id,
+                            AIInterviewConfig.organization_id == self.org_id,
+                            AIInterviewConfig.is_deleted == False,
+                        )
+                    )
+                    current_cfg = current_cfg_res.scalars().first()
+                    if current_cfg:
+                        raise BadRequestException("Only one interview configuration can be created for this stage")
+                    existing_stage_config.config_id = None
+                    if existing_stage_config.acceptance_criteria and isinstance(existing_stage_config.acceptance_criteria, dict):
+                        criteria = existing_stage_config.acceptance_criteria.copy()
+                        criteria.pop("interview_config_id", None)
+                        criteria.pop("candidate_interview_config_id", None)
+                        existing_stage_config.acceptance_criteria = criteria
+                    self.session.add(existing_stage_config)
+            if stage_type_to_update == "live_interview":
+                new_live_cfg = LiveInterviewConfig(
+                    organization_id=self.org_id,
+                    position_id=group.position_id,
+                    title=ic.get("title", "Untitled Interview"),
+                    duration_minutes=ic.get("duration", 60),
+                    instructions=ic.get("instructions"),
+                    suggested_questions=ic.get("questions", {"items": []}),
+                    scoring_rubric=ic.get("live_flow_config"),
+                )
+                self.session.add(new_live_cfg)
+                await self.session.flush()
+
+                mirror_ai_cfg = AIInterviewConfig(
+                    organization_id=self.org_id,
+                    position_id=group.position_id,
+                    title=ic.get("title", "Untitled Interview"),
+                    interview_type="live_ai",
+                    instructions=ic.get("instructions"),
+                    max_retakes=ic.get("max_retakes", 1),
+                    questions=ic.get("questions", {"items": []}),
+                    live_interview_context=ic.get("live_interview_context"),
+                    difficulty=ic.get("difficulty", "Mid Level"),
+                    total_duration_minutes=ic.get("duration", 30),
+                    show_ai_feedback=ic.get("showAIFeedback", True),
+                    recording_required=ic.get("recordingRequired", True),
+                    live_flow_config=ic.get("live_flow_config"),
+                    created_by_user_id=self.user.id,
+                )
+                self.session.add(mirror_ai_cfg)
+                await self.session.flush()
+                config_id = new_live_cfg.id
+                # Store the AI mirror so the candidate live flow can still start a session.
+                ic = {**ic, "candidate_interview_config_id": str(mirror_ai_cfg.config_id)}
+            else:
+                new_cfg = AIInterviewConfig(
+                    organization_id=self.org_id,
+                    position_id=group.position_id,
+                    title=ic.get("title", "Untitled Interview"),
+                    interview_type=ic_type,
+                    instructions=ic.get("instructions"),
+                    max_retakes=ic.get("max_retakes", 1),
+                    questions=ic.get("questions", []),
+                    live_interview_context=ic.get("live_interview_context"),
+                    difficulty=ic.get("difficulty", "Mid Level"),
+                    total_duration_minutes=ic.get("duration", 30),
+                    show_ai_feedback=ic.get("showAIFeedback", True),
+                    recording_required=ic.get("recordingRequired", True),
+                    live_flow_config=ic.get("live_flow_config"),
+                    created_by_user_id=self.user.id,
+                )
+                self.session.add(new_cfg)
+                await self.session.flush()
+                config_id = new_cfg.config_id
+
+        elif data.interview_config_id:
+            if interview_cfg and isinstance(interview_cfg, dict):
+                payload_type = str(interview_cfg.get("interview_type", "")).strip().lower()
+                if payload_type in {"live", "live_ai", "live-interview", "live_interview"}:
+                    stage_type_to_update = "live_interview"
+                elif payload_type:
+                    stage_type_to_update = "ai_interview"
+
+            if not stage_type_to_update:
+                linked_stage = next(
+                    (
+                        sc
+                        for sc in stage_configs
+                        if sc.config_id and str(sc.config_id) == str(data.interview_config_id)
+                    ),
+                    None,
+                )
+                if linked_stage:
+                    stage_type_to_update = linked_stage.stage_type
+
+            if not stage_type_to_update:
+                live_probe_res = await self.session.execute(
+                    select(LiveInterviewConfig).where(
+                        LiveInterviewConfig.id == data.interview_config_id,
+                        LiveInterviewConfig.organization_id == self.org_id,
+                    )
+                )
+                if live_probe_res.scalars().first():
+                    stage_type_to_update = "live_interview"
+
+            if stage_type_to_update == "live_interview":
+                res = await self.session.execute(
+                    select(LiveInterviewConfig).where(
+                        LiveInterviewConfig.id == data.interview_config_id,
+                        LiveInterviewConfig.organization_id == self.org_id,
+                    )
+                )
+                live_cfg = res.scalars().first()
+                if not live_cfg:
+                    raise BadRequestException("Interview configuration not found")
+
+                if interview_cfg:
+                    ic = interview_cfg
+                    live_cfg.title = ic.get("title", live_cfg.title)
+                    live_cfg.instructions = ic.get("instructions", live_cfg.instructions)
+                    live_cfg.duration_minutes = ic.get("duration", live_cfg.duration_minutes)
+                    live_cfg.suggested_questions = ic.get("questions", live_cfg.suggested_questions)
+                    live_cfg.scoring_rubric = ic.get("live_flow_config", live_cfg.scoring_rubric)
+                    self.session.add(live_cfg)
+
+                config_id = live_cfg.id
+                ic_type = "live_ai"
+            else:
+                # Validate existence
+                res = await self.session.execute(
+                    select(AIInterviewConfig).where(
+                        AIInterviewConfig.config_id == data.interview_config_id,
+                            AIInterviewConfig.organization_id == self.org_id,
+                    )
+                )
+                cfg = res.scalars().first()
+                if not cfg:
+                    raise BadRequestException("Interview configuration not found")
+                
+                # Prevent reusing an interview config that is already attached to another group stage
+                assigned_res = await self.session.execute(
+                    select(GroupStageConfig.group_id).where(
+                        GroupStageConfig.config_id == cfg.config_id,
+                        GroupStageConfig.stage_type == "ai_interview",
+                        GroupStageConfig.group_id != group_id,
+                    )
+                )
+                if assigned_res.scalars().first():
+                    raise BadRequestException("Interview configuration is already assigned to another group")
+                
+                if interview_cfg:
+                    ic = interview_cfg
+                    cfg.title = ic.get("title", cfg.title)
+                    cfg.instructions = ic.get("instructions", cfg.instructions)
+                    cfg.max_retakes = ic.get("max_retakes", cfg.max_retakes)
+                    cfg.questions = ic.get("questions", cfg.questions)
+                    cfg.live_interview_context = ic.get("live_interview_context", cfg.live_interview_context)
+                    cfg.difficulty = ic.get("difficulty", cfg.difficulty)
+                    cfg.total_duration_minutes = ic.get("duration", cfg.total_duration_minutes)
+                    cfg.show_ai_feedback = ic.get("showAIFeedback", cfg.show_ai_feedback)
+                    cfg.recording_required = ic.get("recordingRequired", cfg.recording_required)
+                    cfg.live_flow_config = ic.get("live_flow_config", cfg.live_flow_config)
+                    cfg.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+                    self.session.add(cfg)
+                
+                config_id = cfg.config_id
+                ic_type = cfg.interview_type
+
+        else:
+            raise BadRequestException("Provide interview_config_id or create_new with config")
+
+        stage_type_to_update = stage_type_to_update or ("live_interview" if ic_type in ("live", "live_ai") else "ai_interview")
+
+        existing_stage_config = next((sc for sc in stage_configs if sc.stage_type == stage_type_to_update), None)
+        if existing_stage_config and existing_stage_config.config_id and str(existing_stage_config.config_id) != str(config_id):
+            raise BadRequestException("Only one interview configuration can be created for this stage")
+
+        # Update the group's stage config
+        sc = existing_stage_config
+        if sc is None:
+            order_res = await self.session.execute(
+                select(func.coalesce(func.max(GroupStageConfig.stage_order), 0)).where(
+                    GroupStageConfig.group_id == group_id
+                )
+            )
+            max_order = order_res.scalars().first() or 0
+            sc = GroupStageConfig(
+                group_id=group_id,
+                organization_id=self.org_id,
+                stage_type=stage_type_to_update,
+                stage_order=max_order + 1,
+                stage_name="AI Interview" if stage_type_to_update == "ai_interview" else "Live Interview",
+                state="not_started",
+                config_id=config_id,
+            )
+            self.session.add(sc)
+
         if sc:
             criteria = sc.acceptance_criteria or {}
             criteria["interview_config_id"] = str(config_id)
+            if stage_type_to_update == "live_interview" and should_create_new and interview_cfg:
+                candidate_ai_id = ic.get("candidate_interview_config_id")
+                if candidate_ai_id:
+                    criteria["candidate_interview_config_id"] = candidate_ai_id
             sc.acceptance_criteria = criteria
             sc.config_id = config_id
             self.session.add(sc)
@@ -1502,16 +1709,49 @@ class GroupService:
     async def delete_interview(self, group_id: UUID, interview_id: UUID) -> dict:
         """Removes interview ID from stage config and soft-deletes the config itself."""
         # 1. Soft delete the config itself
-        res = await self.session.execute(
-            select(AIInterviewConfig).where(
-                AIInterviewConfig.config_id == interview_id,
-                AIInterviewConfig.organization_id == self.org_id
+        sc_res = await self.session.execute(
+            select(GroupStageConfig).where(
+                GroupStageConfig.group_id == group_id,
+                GroupStageConfig.config_id == interview_id,
             )
         )
-        cfg = res.scalars().first()
-        if cfg:
-            cfg.is_deleted = True
-            self.session.add(cfg)
+        sc = sc_res.scalars().first()
+
+        if sc and sc.stage_type == "live_interview":
+            res = await self.session.execute(
+                select(LiveInterviewConfig).where(
+                    LiveInterviewConfig.id == interview_id,
+                    LiveInterviewConfig.organization_id == self.org_id,
+                )
+            )
+            cfg = res.scalars().first()
+            if cfg:
+                self.session.delete(cfg)
+
+            if sc.acceptance_criteria and isinstance(sc.acceptance_criteria, dict):
+                candidate_ai_id = sc.acceptance_criteria.get("candidate_interview_config_id")
+                if candidate_ai_id:
+                    ai_res = await self.session.execute(
+                        select(AIInterviewConfig).where(
+                            AIInterviewConfig.config_id == UUID(str(candidate_ai_id)),
+                            AIInterviewConfig.organization_id == self.org_id,
+                        )
+                    )
+                    ai_cfg = ai_res.scalars().first()
+                    if ai_cfg:
+                        ai_cfg.is_deleted = True
+                        self.session.add(ai_cfg)
+        else:
+            res = await self.session.execute(
+                select(AIInterviewConfig).where(
+                    AIInterviewConfig.config_id == interview_id,
+                    AIInterviewConfig.organization_id == self.org_id
+                )
+            )
+            cfg = res.scalars().first()
+            if cfg:
+                cfg.is_deleted = True
+                self.session.add(cfg)
 
         # 2. Cleanup GroupStageConfig referencing this interview
         sc_res = await self.session.execute(
@@ -1522,11 +1762,16 @@ class GroupService:
         stage_configs = sc_res.scalars().all()
         for sc in stage_configs:
             if sc.acceptance_criteria and isinstance(sc.acceptance_criteria, dict):
-                if str(sc.acceptance_criteria.get("interview_config_id")) == str(interview_id):
+                if str(sc.acceptance_criteria.get("interview_config_id")) == str(interview_id) or str(sc.config_id) == str(interview_id):
                     criteria = sc.acceptance_criteria.copy()
                     del criteria["interview_config_id"]
+                    criteria.pop("candidate_interview_config_id", None)
                     sc.acceptance_criteria = criteria
+                    sc.config_id = None
                     self.session.add(sc)
+            elif str(sc.config_id) == str(interview_id):
+                sc.config_id = None
+                self.session.add(sc)
 
         await self.session.commit()
         return {"status": 1, "message": "Interview deleted successfully"}
@@ -1735,6 +1980,69 @@ class GroupService:
             ]
         )
 
+    async def _generate_and_send_group_credentials(
+        self,
+        candidate_ids: list[UUID],
+        position_id: UUID,
+        group: CandidateGroup,
+    ) -> None:
+        """Generate a new password for each candidate added to a group,
+        send the plaintext password via email, and store the bcrypt hash in DB.
+        Also logs each email to EmailLog for debugging."""
+        import secrets
+        import string
+        from app.core.security import hash_password
+        from app.services.email import EmailService
+
+        # Fetch applications joined with profiles for the given candidate_ids
+        query = (
+            select(CandidateApplication, CandidateProfile)
+            .join(CandidateProfile, CandidateApplication.candidate_id == CandidateProfile.id)
+            .where(
+                CandidateApplication.candidate_id.in_(candidate_ids),
+                CandidateApplication.position_id == position_id,
+                CandidateApplication.organization_id == self.org_id,
+            )
+        )
+        res = await self.session.execute(query)
+        rows = res.all()
+
+        alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+
+        for app, profile in rows:
+            # 1. Generate random 12-char password (plaintext)
+            temp_password = ''.join(secrets.choice(alphabet) for _ in range(12))
+
+            # 2. Store hashed password on the candidate profile
+            profile.password_hash = hash_password(temp_password)
+            self.session.add(profile)
+
+            # 3. Send plaintext credentials via email (email + password + login URL)
+            try:
+                await EmailService.send_group_credentials_email(
+                    email=profile.email,
+                    name=profile.full_name,
+                    group_name=group.group_name,
+                    temp_password=temp_password,   # plaintext, NOT the hash
+                    group_id=str(group.id),
+                )
+            except Exception as e:
+                import logging
+                logging.getLogger(__name__).error(
+                    f"Failed to send group credentials email to {profile.email}: {e}"
+                )
+
+            # 4. Log email to EmailLog for debugging
+            email_log = EmailLog(
+                organization_id=self.org_id,
+                recipient_email=profile.email,
+                subject="EraMatch - Your New Group Credentials",
+                template_type="group_credentials",
+                status="sent",
+                sent_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            )
+            self.session.add(email_log)
+
     async def create_group(self, data: GroupCreateRequest) -> CandidateGroup:
         """Create a new candidate group."""
         if self.user.role == "technical":
@@ -1777,6 +2085,10 @@ class GroupService:
                     CandidateApplication.organization_id == self.org_id
                 )
                 .values(group_id=group.id, status="screening")
+            )
+            # Generate and send credentials for candidates added to this new group
+            await self._generate_and_send_group_credentials(
+                data.candidate_ids, data.position_id, group
             )
 
         # 4. Audit Log

--- a/backend/app/services/group.py
+++ b/backend/app/services/group.py
@@ -1166,7 +1166,7 @@ class GroupService:
             # 2. Add an Offer record so it's tracked explicitly
             new_offer = Offer(
                 application_id=app.id,
-                organization_id=self.current_user.organization_id,
+                organization_id=self.user.organization_id,
                 position_id=app.position_id,
                 status="sent"
             )
@@ -1175,8 +1175,8 @@ class GroupService:
             # 3. Create a system log / activity log
             log = SystemLog(
                 event_type="offer_sent",
-                user_id=self.current_user.id,
-                organization_id=self.current_user.organization_id,
+                user_id=self.user.id,
+                organization_id=self.user.organization_id,
                 entity_type="candidate_application",
                 entity_id=app.id,
                 details={"candidate_name": profile.full_name, "subject": subject}
@@ -1965,7 +1965,7 @@ class GroupService:
             )
             self.session.add(job)
             await self.session.flush()
-            jd_text = str(position.job_description or position.description or "")
+            jd_text = str(position.job_description or "")
             queued_jobs.append((job.id, profile.id, github_url, jd_text))
 
         await self.session.commit()


### PR DESCRIPTION
This PR contain initial iteration of candidate recruiter integration

It includes:

- group-aware candidate login using [group_id](vscode-file://vscode-app/d:/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from the login URL
- backend auth support for group-scoped candidate lookup
- interview session start/completion synchronization with the backend
- live interview config resolution and completion notification fixes
- recruiter group page cleanup for interview create/edit state
- assessment section support for selecting how many variants each candidate receives
- duplicate assessment prevention and interview config deduplication
- updated email workflows for group invitation and candidate credentials
- backend fixes for stale interview references and notification JSON payload handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Login now supports group-based access with group-specific URLs
  * New "Questions per candidate" configuration option for assessments
  * Group onboarding with credentials email delivery

* **Improvements**
  * Interview configuration now dynamically loaded from backend
  * Enhanced interview stage management supporting multiple interview types
  * Reinforced assessment constraints (single tech assessment per group)
  * Group-specific login links and credentials in invitation emails
  * Improved candidate transfer process with credential handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->